### PR TITLE
fix: fixing bug where responses don't get rewritten with pretty-printing

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -35,7 +35,7 @@ const rewriteResRaw = (res: Response) => {
     if (isJsonContent && body instanceof Buffer) {
       try {
         const bodyJson = JSON.parse(body.toString('utf8'));
-        if (bodyJson.data) {
+        if (bodyJson && bodyJson.data) {
           const newResponseData = rewriteHandler.rewriteResponse(bodyJson.data);
           const newResBodyJson = { ...bodyJson, data: newResponseData };
           // assume this was pretty-printed if we're here and not in the res.json handler

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -3,4 +3,8 @@ declare namespace Express {
   interface Request {
     _rewriteHandler?: import('graphql-query-rewriter').RewriteHandler;
   }
+
+  interface Response {
+    _isRewritten?: boolean;
+  }
 }

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -166,7 +166,7 @@ describe('middleware test', () => {
     });
   });
 
-  const setupMutationApp = () => {
+  const setupMutationApp = (extraExpressGraphqlOpts: any = {}) => {
     const app = express();
 
     app.use(
@@ -190,7 +190,8 @@ describe('middleware test', () => {
       '/graphql',
       graphqlHTTP({
         schema,
-        rootValue
+        rootValue,
+        ...extraExpressGraphqlOpts
       })
     );
     return app;
@@ -399,6 +400,52 @@ describe('middleware test', () => {
       .post('/graphql')
       .send({ query: deprecatedQuery });
     expect(invalidQueryRes.body).toEqual('jimmy');
+  });
+
+  it('is able to rewriter responses with pretty printing enabled on express-graphql', async () => {
+    const app = setupMutationApp({ pretty: true });
+    // in the past, we didn't use input or output types correctly
+    // so we need to rewrite the query to this old query will work still
+    const deprecatedQuery = `
+      mutation makePokemonWithWrongType($name: String!) {
+        makePokemon(name: $name) {
+          id
+          name
+        }
+      }
+    `;
+
+    const deprecatedRes = await request(app)
+      .post('/graphql')
+      .send({ query: deprecatedQuery, variables: { name: 'Squirtle' } });
+    expect(deprecatedRes.body.errors).toBe(undefined);
+    expect(deprecatedRes.body.data.makePokemon).toEqual({
+      id: '17',
+      name: 'Squirtle'
+    });
+
+    // the new version of the query should still work with no problem though
+    const newQuery = `
+      mutation makePokemon($input: MakePokemonInput!) {
+        makePokemon(input: $input) {
+          pokemon {
+            id
+            name
+          }
+        }
+      }
+    `;
+
+    const newRes = await request(app)
+      .post('/graphql')
+      .send({ query: newQuery, variables: { input: { name: 'Squirtle' } } });
+    expect(newRes.body.errors).toBe(undefined);
+    expect(newRes.body.data.makePokemon).toEqual({
+      pokemon: {
+        id: '17',
+        name: 'Squirtle'
+      }
+    });
   });
 
   it('throws on invalid graphql if ignoreParsingErrors === false', async () => {


### PR DESCRIPTION
[express-graphql](https://github.com/graphql/express-graphql) uses raw `response.setHeader()` and `response.end()` to send responses when pretty-printing is enabled. express-graphql-query-rewriter currently only handles rewriting responses sent via `response.json()`, which gets bypassed for pretty-printing. This PR allows the query rewriter to properly rewrite responses sent via `response.end()` and `response.setHeader()` as well.